### PR TITLE
Fixes princeton-nlp/DinkyTrain#5

### DIFF
--- a/scripts/convert_dsfs_ckpt_to_fs_ckpt.py
+++ b/scripts/convert_dsfs_ckpt_to_fs_ckpt.py
@@ -22,6 +22,10 @@ def convert_dsfs_ckpt_to_fs_ckpt(fr, to):
     new_ckpt["cfg"]['common']['deepspeed_cuda_kernel'] = False
     new_ckpt["cfg"]['task'].deepspeed_cuda_kernel = False
 
+    if hasattr(old_ckpt["cfg"]['model'], 'arch'):
+        new_ckpt["cfg"]['model'].arch = old_ckpt["cfg"]['model'].arch.split('deepspeed_', 1)[-1]
+    if hasattr(old_ckpt["cfg"]['model'], '_name'):
+        new_ckpt["cfg"]['model']._name = old_ckpt["cfg"]['model']._name.split('deepspeed_', 1)[-1]
     new_ckpt["cfg"]['model'].deepspeed_stochastic_mode = False
     new_ckpt["cfg"]['common']['deepspeed_stochastic_mode'] = False
     new_ckpt["cfg"]['task'].deepspeed_stochastic_mode = False


### PR DESCRIPTION
As pointed out in #5, there is a problem in https://github.com/princeton-nlp/DinkyTrain/blob/main/scripts/convert_fs_ckpt_to_hf_ckpt.py that loads the incorrect architecture for models trained with DeepSpeed, even with FROM_DS=1. 

This is caused by a misconfiguration where `new_ckpt["cfg"]['model'].arch` and `new_ckpt["cfg"]['model']._name` retain values `deepspeed_roberta_x` causing https://github.com/princeton-nlp/DinkyTrain/blob/1f26b99815547cd09762cd34dc980571d10454a5/scripts/convert_fs_ckpt_to_hf_ckpt.py#L62 to load DeepSpeedRobertaModel instead of RobertaModel.

This PR improves the https://github.com/princeton-nlp/DinkyTrain/blob/main/scripts/convert_dsfs_ckpt_to_fs_ckpt.py script to convert DeepSpeed models to fairseq by removing any `deepspeed_` prefix from `new_ckpt["cfg"]['model'].arch` and `new_ckpt["cfg"]['model']._name`.